### PR TITLE
fixed char for trail/ removed trailing space ;)

### DIFF
--- a/autoload/cyclist.vim
+++ b/autoload/cyclist.vim
@@ -109,9 +109,9 @@ call cyclist#add_listchar_option_set("default", {
         \ 'eol': '↲',
         \ 'tab': '» ',
         \ 'space': '',
-        \ 'trail': '𝁢',
+        \ 'trail': '·',
         \ 'extends': '…',
-        \ 'precedes': '…',    
+        \ 'precedes': '…',
         \ 'conceal': '┊',
         \ 'nbsp': '☠',
         \ })


### PR DESCRIPTION
I tried out your new config and was wondering why trailing spaces did not render correctly. Here is a small fix. 

BTW: Thx for your engagement in neovim and I'm still learning Telescope :)